### PR TITLE
Soundtemplate filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apiaudio",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apiaudio",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "api.audio Javascript SDK",
   "author": "salih <salih@aflorithmic.ai>",
   "license": "MIT",

--- a/src/Sound.ts
+++ b/src/Sound.ts
@@ -8,9 +8,8 @@ export class SoundClass {
   #RequestClass!: RequestBase;
   #url = "";
   #file_url = "";
-  #bg_url = "";
   #template_url = "";
-  #template_url_v2 = "";
+  #list_sound_templates_filtering = "";
   #parameters_url = "";
 
   public configure(config: IConfig, requestClass: RequestBase): void {
@@ -19,10 +18,9 @@ export class SoundClass {
     }
     this.#url = `${config.baseUrl}/sound`;
     this.#file_url = `${config.baseUrl}/file/sound`;
-    this.#bg_url = `${config.baseUrl}/file/background_track`;
     this.#template_url = `${config.baseUrl}/file/soundtemplates`;
-    this.#template_url_v2 = `${config.baseUrl}/sound/list`;
-    this.#parameters_url = `${config.baseUrl}/sound/parameters`;
+    this.#list_sound_templates_filtering = `${config.baseUrl}/sound/template`;
+    this.#parameters_url = `${config.baseUrl}/sound/parameter`;
     this.#initialized = true;
     this.#RequestClass = requestClass;
   }
@@ -51,13 +49,13 @@ export class SoundClass {
   }
 
   /**
-   * List all background tracks including a 15 seconds audio snippet
+   * List all the available sound templates (allows optional filtering)
    */
-  public list(): Promise<unknown> {
+  public list(params?: ISoundTemplatesFilteringBody): Promise<unknown> {
     if (!this.#initialized) {
       isInitializedError();
     }
-    return this.#RequestClass.getRequest(this.#bg_url);
+    return this.#RequestClass.getRequest(this.#list_sound_templates_filtering, "", { params });
   }
 
   /**
@@ -68,16 +66,6 @@ export class SoundClass {
       isInitializedError();
     }
     return this.#RequestClass.getRequest(this.#template_url);
-  }
-
-  /**
-   * List all the available sound templates (newer version, allows optional filtering)
-   */
-  public list_v2(params?: ISoundTemplatesFilteringBody): Promise<unknown> {
-    if (!this.#initialized) {
-      isInitializedError();
-    }
-    return this.#RequestClass.getRequest(this.#template_url_v2, "", { params });
   }
 
   /**
@@ -96,9 +84,8 @@ export class SoundClass {
     this.#RequestClass = undefined;
     this.#url = "";
     this.#file_url = "";
-    this.#bg_url = "";
     this.#template_url = "";
-    this.#template_url_v2 = "";
+    this.#list_sound_templates_filtering = "";
     this.#parameters_url = "";
   }
 }

--- a/src/Sound.ts
+++ b/src/Sound.ts
@@ -1,7 +1,7 @@
 import { apiaudio } from "./apiaudio";
 import { isInitializedError, isSubmoduleAlreadyInitializedError } from "./Errors";
 import { RequestBase } from "./RequestBase";
-import { IConfig, ISoundBody } from "./types";
+import { IConfig, ISoundBody, ISoundTemplatesFilteringBody } from "./types";
 
 export class SoundClass {
   #initialized = false;
@@ -10,6 +10,8 @@ export class SoundClass {
   #file_url = "";
   #bg_url = "";
   #template_url = "";
+  #template_url_v2 = "";
+  #parameters_url = "";
 
   public configure(config: IConfig, requestClass: RequestBase): void {
     if (this.#initialized) {
@@ -19,6 +21,8 @@ export class SoundClass {
     this.#file_url = `${config.baseUrl}/file/sound`;
     this.#bg_url = `${config.baseUrl}/file/background_track`;
     this.#template_url = `${config.baseUrl}/file/soundtemplates`;
+    this.#template_url_v2 = `${config.baseUrl}/sound/list`;
+    this.#parameters_url = `${config.baseUrl}/sound/parameters`;
     this.#initialized = true;
     this.#RequestClass = requestClass;
   }
@@ -66,6 +70,26 @@ export class SoundClass {
     return this.#RequestClass.getRequest(this.#template_url);
   }
 
+  /**
+   * List all the available sound templates (newer version, allows optional filtering)
+   */
+  public list_v2(params?: ISoundTemplatesFilteringBody): Promise<unknown> {
+    if (!this.#initialized) {
+      isInitializedError();
+    }
+    return this.#RequestClass.getRequest(this.#template_url_v2, "", { params });
+  }
+
+  /**
+   * List all allowed filtering parameters
+   */
+  public parameters(): Promise<unknown> {
+    if (!this.#initialized) {
+      isInitializedError();
+    }
+    return this.#RequestClass.getRequest(this.#parameters_url);
+  }
+
   public reset(): void {
     this.#initialized = false;
     // @ts-ignore
@@ -74,6 +98,8 @@ export class SoundClass {
     this.#file_url = "";
     this.#bg_url = "";
     this.#template_url = "";
+    this.#template_url_v2 = "";
+    this.#parameters_url = "";
   }
 }
 

--- a/src/__tests__/Sound.test.ts
+++ b/src/__tests__/Sound.test.ts
@@ -178,4 +178,21 @@ describe("Sound operations", () => {
       throw new Error("test failed");
     }
   });
+
+  test("It should return an error when sending a wrong filtering parameter", async () => {
+    try {
+      const bad_tag_name = "bad_tag_name";
+      const rawResult: any = await Sound.list_v2({ bad_tag_name });
+      expect(rawResult).toHaveProperty("message");
+      expect(rawResult).toHaveProperty("allowedFilteringParameters");
+      const { message, allowedFilteringParameters } = rawResult;
+      expect(Array.isArray(allowedFilteringParameters)).toBe(true);
+      console.log(message);
+      expect(typeof message).toEqual("string");
+      expect(message.includes(bad_tag_name)).toBe(true);
+    } catch (e) {
+      console.error(e);
+      throw new Error("test failed");
+    }
+  });
 });

--- a/src/__tests__/Sound.test.ts
+++ b/src/__tests__/Sound.test.ts
@@ -76,9 +76,12 @@ describe("Sound operations", () => {
   test("It should create the sound template", async () => {
     try {
       const bg_tracks: any = await Sound.list();
+      expect(bg_tracks).toHaveProperty("templates");
+      const { templates } = bg_tracks;
+      const backgroundTrackId = templates[0]["soundTemplateId"];
       const rawResult: any = await Sound.create({
         scriptId: createdScriptId,
-        backgroundTrackId: bg_tracks["tracklist"][0]
+        backgroundTrackId
       });
       expect(rawResult.url.startsWith("https://")).toBe(true);
       expect(rawResult.url).toMatch(`${testValues}/${testValues}/${testValues}`);
@@ -98,21 +101,6 @@ describe("Sound operations", () => {
       throw new Error("test failed");
     }
   }, 30000);
-
-  test("It should list all the background tracks", async () => {
-    try {
-      const rawResult: any = await Sound.list();
-      expect(rawResult).toHaveProperty("tracklist");
-      expect(rawResult).toHaveProperty("trackUrls");
-      expect(Array.isArray(rawResult?.tracklist)).toBe(true);
-      for (const value in rawResult?.trackUrls) {
-        expect(typeof value).toEqual("string");
-      }
-    } catch (e) {
-      console.error(e);
-      throw new Error("test failed");
-    }
-  });
 
   test("It should list all the sound templates", async () => {
     try {
@@ -149,7 +137,7 @@ describe("Sound operations", () => {
 
   test("It should list all the sound templates", async () => {
     try {
-      const rawResult: any = await Sound.list_v2();
+      const rawResult: any = await Sound.list();
       expect(rawResult).toHaveProperty("templates");
       const { templates } = rawResult;
       allTemplatesCount = templates.length;
@@ -168,7 +156,7 @@ describe("Sound operations", () => {
 
   test("It should list all the sound templates that match some filtering parameters", async () => {
     try {
-      const rawResult: any = await Sound.list_v2({ tags: "melodic,happy", genre: "electronic" });
+      const rawResult: any = await Sound.list({ tags: "melodic,happy", genre: "electronic" });
       expect(rawResult).toHaveProperty("templates");
       const { templates } = rawResult;
       expect(Array.isArray(templates)).toBe(true);
@@ -182,7 +170,7 @@ describe("Sound operations", () => {
   test("It should return an error when sending a wrong filtering parameter", async () => {
     const bad_tag_name = "bad_tag_name";
     try {
-      await Sound.list_v2({ bad_tag_name });
+      await Sound.list({ bad_tag_name });
     } catch (e) {
       expect(e).toHaveProperty("message");
       expect(e).toHaveProperty("allowedFilteringParameters");

--- a/src/__tests__/Sound.test.ts
+++ b/src/__tests__/Sound.test.ts
@@ -189,7 +189,7 @@ describe("Sound operations", () => {
       const { message, allowedFilteringParameters } = e;
       expect(Array.isArray(allowedFilteringParameters)).toBe(true);
       expect(typeof message).toEqual("string");
-      expect(message.includes(bad_tag_name)).toBe(true);
+      expect(message).toMatch(bad_tag_name);
     }
   });
 });

--- a/src/__tests__/Sound.test.ts
+++ b/src/__tests__/Sound.test.ts
@@ -27,6 +27,7 @@ describe("Sound module initialization", () => {
 });
 
 describe("Sound operations", () => {
+  let allTemplatesCount: number;
   beforeEach(() => {
     apiaudio.reset();
     apiaudio.configure({ apiKey, debug });
@@ -124,6 +125,54 @@ describe("Sound operations", () => {
         expect(template).toHaveProperty("contents");
         expect(Array.isArray(template?.contents)).toBe(true);
       }
+    } catch (e) {
+      console.error(e);
+      throw new Error("test failed");
+    }
+  });
+
+  test("It should list all the sound template allowed filtering parameters", async () => {
+    try {
+      const parameters: any = await Sound.parameters();
+      expect(typeof parameters).toEqual("object");
+      for (const parameter in parameters) {
+        expect(Array.isArray(parameters[parameter])).toBe(true);
+        for (const value of parameters[parameter]) {
+          expect(typeof value).toEqual("string");
+        }
+      }
+    } catch (e) {
+      console.error(e);
+      throw new Error("test failed");
+    }
+  });
+
+  test("It should list all the sound templates", async () => {
+    try {
+      const rawResult: any = await Sound.list_v2();
+      expect(rawResult).toHaveProperty("templates");
+      const { templates } = rawResult;
+      allTemplatesCount = templates.length;
+      expect(Array.isArray(templates)).toBe(true);
+      for (const template of templates) {
+        expect(template).toHaveProperty("templateName");
+        expect(template).toHaveProperty("description");
+        expect(Array.isArray(template?.contents)).toBe(true);
+        expect(Array.isArray(template?.tags)).toBe(true);
+      }
+    } catch (e) {
+      console.error(e);
+      throw new Error("test failed");
+    }
+  });
+
+  test("It should list all the sound templates that match some filtering parameters", async () => {
+    try {
+      const rawResult: any = await Sound.list_v2({ tags: "melodic,happy", genre: "electronic" });
+      expect(rawResult).toHaveProperty("templates");
+      const { templates } = rawResult;
+      expect(Array.isArray(templates)).toBe(true);
+      expect(templates.length).toBeLessThanOrEqual(allTemplatesCount);
     } catch (e) {
       console.error(e);
       throw new Error("test failed");

--- a/src/__tests__/Sound.test.ts
+++ b/src/__tests__/Sound.test.ts
@@ -111,7 +111,9 @@ describe("Sound operations", () => {
       for (const template of templates) {
         expect(template).toHaveProperty("name");
         expect(template).toHaveProperty("contents");
-        expect(Array.isArray(template?.contents)).toBe(true);
+        if (template?.contents) {
+          expect(Array.isArray(template.contents)).toBe(true);
+        }
       }
     } catch (e) {
       console.error(e);
@@ -140,8 +142,8 @@ describe("Sound operations", () => {
       const rawResult: any = await Sound.list();
       expect(rawResult).toHaveProperty("templates");
       const { templates } = rawResult;
-      allTemplatesCount = templates.length;
       expect(Array.isArray(templates)).toBe(true);
+      allTemplatesCount = templates.length;
       for (const template of templates) {
         expect(template).toHaveProperty("templateName");
         expect(template).toHaveProperty("description");

--- a/src/__tests__/Sound.test.ts
+++ b/src/__tests__/Sound.test.ts
@@ -180,19 +180,16 @@ describe("Sound operations", () => {
   });
 
   test("It should return an error when sending a wrong filtering parameter", async () => {
+    const bad_tag_name = "bad_tag_name";
     try {
-      const bad_tag_name = "bad_tag_name";
-      const rawResult: any = await Sound.list_v2({ bad_tag_name });
-      expect(rawResult).toHaveProperty("message");
-      expect(rawResult).toHaveProperty("allowedFilteringParameters");
-      const { message, allowedFilteringParameters } = rawResult;
+      await Sound.list_v2({ bad_tag_name });
+    } catch (e) {
+      expect(e).toHaveProperty("message");
+      expect(e).toHaveProperty("allowedFilteringParameters");
+      const { message, allowedFilteringParameters } = e;
       expect(Array.isArray(allowedFilteringParameters)).toBe(true);
-      console.log(message);
       expect(typeof message).toEqual("string");
       expect(message.includes(bad_tag_name)).toBe(true);
-    } catch (e) {
-      console.error(e);
-      throw new Error("test failed");
     }
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,16 @@ export interface ISoundBody {
   backgroundTrackId: string;
 }
 
+export interface ISoundTemplatesFilteringBody {
+  /** Placeholder allowed parameters to be updated after database is completed */
+  tags?: string;
+  industryExamples?: string;
+  genre?: string;
+  contents?: string;
+  tempo?: string;
+  [key: string]: any;
+}
+
 export type SectionConfig = {
   /** Voice name. See the list of available voices using Voice resource. Default voice is "Joanna".
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,12 +57,16 @@ export interface ISoundBody {
 }
 
 export interface ISoundTemplatesFilteringBody {
-  /** Placeholder allowed parameters to be updated after database is completed */
-  tags?: string;
+  /** Try with one or more (separated by commas) of: news, travel, business, relaxation, fitness, relax, children stories */
   industryExamples?: string;
-  genre?: string;
+  /** Try with one or more (separated by commas) of: intro, main, outro, effect1, effect2, main outro, droid_main, chewie_main, effect3, ambience, only effects */
   contents?: string;
+  /** Try with one of: electronic, acoustic, atmospheric, abstract, rock */
+  genre?: string;
+  /** Try with one of: mid, up, down, uptempo */
   tempo?: string;
+  /** Try with one or more (separated by commas) of: intense, minimal, reflective, melodic, happy, nostalgic, focus, energetic, uplifting, active, relaxed, ambience, mysterious, positive, informative, workout, work, meditation, travel, full silence */
+  tags?: string;
   [key: string]: any;
 }
 


### PR DESCRIPTION
Added filtering for soundtemplates and retrieving allowed filtering parameters

Todo: 
 - [x] add placeholder filtering parmeters (once db is completed ETA 2 weeks or so)
 - [x] fix last sound test (I expect it to throw an error, but it does not get cached properly)
 - [x] sit down and see if we can deplrecate `.list()` for `Sound`, or how are we going to play it